### PR TITLE
Tick hadoop-azure package for listStatus() fix

### DIFF
--- a/underfs/adl/pom.xml
+++ b/underfs/adl/pom.xml
@@ -23,7 +23,7 @@
 
   <properties>
     <!-- The hadoop client version adl-hadoop depends on -->
-    <adl.hadoop.version>2.9.1</adl.hadoop.version>
+    <adl.hadoop.version>2.10.0</adl.hadoop.version>
     <!-- The following paths need to be defined here as well as in the parent pom so that mvn can -->
     <!-- run properly from sub-project directories -->
     <build.path>${project.parent.parent.basedir}/build</build.path>

--- a/underfs/wasb/pom.xml
+++ b/underfs/wasb/pom.xml
@@ -23,7 +23,7 @@
 
   <properties>
     <!-- The hadoop client version wasb-hadoop depends on -->
-    <wasb.hadoop.version>2.7.3.2.6.1.0-129</wasb.hadoop.version>
+    <wasb.hadoop.version>2.10.0</wasb.hadoop.version>
     <!-- The following paths need to be defined here as well as in the parent pom so that mvn can -->
     <!-- run properly from sub-project directories -->
     <build.path>${project.parent.parent.basedir}/build</build.path>


### PR DESCRIPTION
Bump hadoop-azure to 2.10.0, it includes a performance fix for `listStatus()` when called on a directory with large number of files.

See https://issues.apache.org/jira/browse/HADOOP-15547