### PR TITLE
Stop printing return result in RPC call exceeding-time-threshold warn…

### DIFF
--- a/core/common/src/main/java/alluxio/AbstractClient.java
+++ b/core/common/src/main/java/alluxio/AbstractClient.java
@@ -369,8 +369,8 @@ public abstract class AbstractClient implements Client {
       long duration = System.currentTimeMillis() - startMs;
       logger.debug("Exit (OK): {}({}) in {} ms", rpcName, debugDesc, duration);
       if (duration >= mRpcThreshold) {
-        logger.warn("{}({}) returned {} in {} ms (>={} ms)",
-            rpcName, String.format(description, args), ret, duration, mRpcThreshold);
+        logger.warn("{}({}) returned in {} ms (>={} ms)",
+            rpcName, String.format(description, args), duration, mRpcThreshold);
       }
       return ret;
     } catch (Exception e) {

--- a/core/server/master/src/main/java/alluxio/master/block/DefaultBlockMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/block/DefaultBlockMaster.java
@@ -908,7 +908,7 @@ public final class DefaultBlockMaster extends CoreMaster implements BlockMaster 
     registerWorkerInternal(workerId);
     // Invalidate cache to trigger new build of worker info list
     mWorkerInfoCache.invalidate(WORKER_INFO_CACHE_KEY);
-    LOG.debug("registerWorker(): {}", worker);
+    LOG.info("registerWorker(): {}", worker.getWorkerAddress());
   }
 
   @Override

--- a/core/server/master/src/main/java/alluxio/master/block/DefaultBlockMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/block/DefaultBlockMaster.java
@@ -908,7 +908,7 @@ public final class DefaultBlockMaster extends CoreMaster implements BlockMaster 
     registerWorkerInternal(workerId);
     // Invalidate cache to trigger new build of worker info list
     mWorkerInfoCache.invalidate(WORKER_INFO_CACHE_KEY);
-    LOG.info("registerWorker(): {}", worker);
+    LOG.debug("registerWorker(): {}", worker);
   }
 
   @Override

--- a/shell/src/main/java/alluxio/cli/fs/command/DistributedLoadCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/DistributedLoadCommand.java
@@ -269,6 +269,7 @@ public final class DistributedLoadCommand extends AbstractFileSystemCommand {
     URIStatus status = mFileSystem.getStatus(filePath);
     if (status.isFolder()) {
       List<URIStatus> statuses = mFileSystem.listStatus(filePath);
+      System.out.println("Files loaded, starting distribution load");
       for (URIStatus uriStatus : statuses) {
         if (uriStatus.isFolder()) {
           AlluxioURI subPath = new AlluxioURI(uriStatus.getPath());


### PR DESCRIPTION
…ings, since the return result can be too big to print